### PR TITLE
fix(auth): Prevent infinite recursion in permission check

### DIFF
--- a/lib/stores/auth-store.js
+++ b/lib/stores/auth-store.js
@@ -4,7 +4,7 @@ import Cookies from 'js-cookie'
 import { api } from '@/lib/api'
 import { mockAPI, mockHelpers } from '@/lib/mock-data'
 import { getRoleDashboardPath, canRoleAccessPath } from '@/lib/utils/role-redirect'
-import { ROLE_DEFINITIONS, UserRole, UserStatus, hasPermission } from '@/lib/constants/enums'
+import { ROLE_DEFINITIONS, UserRole, UserStatus, hasPermission as hasPermissionHelper } from '@/lib/constants/enums'
 
 const USE_MOCK_DATA = process.env.NEXT_PUBLIC_USE_MOCK_DATA === 'true'
 
@@ -564,7 +564,7 @@ export const useAuthStore = create(
       hasPermission: (permission) => {
         const { user } = get()
         if (!user) return false
-        return hasPermission(user.role, permission)
+        return hasPermissionHelper(user.role, permission)
       },
 
       // Access control methods


### PR DESCRIPTION
This commit fixes a critical bug that caused an 'access denied' error and a broken UI after every successful login.

The root cause was an infinite recursion in the `hasPermission` method within the `lib/stores/auth-store.js` file. The method was calling itself instead of the intended helper function due to a name collision on the import. This would cause the application to crash whenever a user's permissions were checked by the `RoleGuard` component.

The fix involves:
1.  Renaming the imported `hasPermission` function to `hasPermissionHelper` to resolve the name collision.
2.  Updating the `hasPermission` method in the store to call the correctly named helper function.

This change ensures that permission checks complete successfully, allowing the login and authorization flow to work as intended.